### PR TITLE
Use "macOS" style when running on macOS

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,6 +56,8 @@ int main(int argc, char *argv[])
     if (qEnvironmentVariableIsEmpty("QT_QUICK_CONTROLS_STYLE")) {
 #ifdef Q_OS_LINUX
         QQuickStyle::setStyle(QStringLiteral("org.kde.desktop"));
+#elif defined(Q_OS_MACOS)
+        QQuickStyle::setStyle(QStringLiteral("macOS"));
 #else
         QQuickStyle::setStyle(QStringLiteral("FluentWinUI3"));
 #endif


### PR DESCRIPTION
Both the "org.kde.desktop" and "FluentWinUI3" styles have strange sizing and appearance issues on macOS. While these are probably solvable with some effort, the "macOS" style fixes all the issues out-of-the-box, so may as well just use it.